### PR TITLE
test: See that `fillBuffer` bubbles exception

### DIFF
--- a/gson/src/main/java/com/google/gson/stream/JsonReader.java
+++ b/gson/src/main/java/com/google/gson/stream/JsonReader.java
@@ -211,6 +211,8 @@ import java.util.Objects;
  * @since 1.6
  */
 public class JsonReader implements Closeable {
+  public static boolean SIM_EXC = false;
+
   private static final long MIN_INCOMPLETE_INTEGER = Long.MIN_VALUE / 10;
 
   public static final int PEEKED_NONE = 0;
@@ -1480,6 +1482,8 @@ public class JsonReader implements Closeable {
 
     pos = 0;
     int total;
+    // Cyrille recommendation
+    if (SIM_EXC) throw new IOException("Simulated I/O error");
     while ((total = in.read(buffer, limit, buffer.length - limit)) != -1) {
       limit += total;
 

--- a/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
+++ b/gson/src/test/java/com/google/gson/stream/JsonReaderTest.java
@@ -28,6 +28,7 @@ import static com.google.gson.stream.JsonToken.NUMBER;
 import static com.google.gson.stream.JsonToken.STRING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 import com.google.gson.Strictness;
 import java.io.EOFException;
@@ -2125,7 +2126,7 @@ public final class JsonReaderTest {
   }
 
   @Test
-  public void reachUnreachedCodeAndReturnCorrectResult() throws IOException {
+  public void peekKeywordReachUnreachedCodeAndReturnCorrectResult() throws IOException {
 
       JsonReader reader = new JsonReader(reader("tru"));
       boolean unused = reader.fillBuffer(1); // Fill the buffer initially
@@ -2139,6 +2140,21 @@ public final class JsonReaderTest {
 
       // Assert that the method returns PEEKED_NONE
       assertEquals(JsonReader.PEEKED_NONE, result);
+  }
+
+  @Test
+  public void fillBufferThrowIOExceptionOnInvalidRead() {
+    JsonReader reader = new JsonReader(reader("something :)"));
+    JsonReader.SIM_EXC = true; // Simulate I/O error in fillBuffer
+
+    try {
+      boolean unused = reader.fillBuffer(1);
+      JsonReader.SIM_EXC = false; // Turn of simulated I/O error for other tests
+      fail("Expected IOException to be thrown");
+    } catch (IOException e) {
+      JsonReader.SIM_EXC = false; // Turn of simulated I/O error for other tests
+      assertEquals("Simulated I/O error", e.getMessage());
+    }
   }
 
   /** Test that an unclosed c-style comment throws invalid syntax exception. */


### PR DESCRIPTION
Added a test case which simulates the `read` in `fillBuffer` throwing an IOException.